### PR TITLE
Fix problem with ts_schema:generate not being executed after Migration

### DIFF
--- a/lib/tasks/ts_schema_tasks.rake
+++ b/lib/tasks/ts_schema_tasks.rake
@@ -12,6 +12,7 @@ end
 
 namespace :db do
   def auto_generate_and_save_file
+    Rails.application.reloader.reload!
     TsSchema.output_file if TsSchema.configuration.auto_generate
   end
 


### PR DESCRIPTION
SchemaGenerator is running Rails.application.eager_load!, but if old model information is loaded before the db:migration task is executed, it will refer to it.
If ts_schema:generate is executed in that state, it will output the old schema.
https://github.com/aviemet/ts_schema/blob/main/lib/ts_schema/schema_generator.rb#L15

In this fix, models information is cleared before ts_schema:generate and executed with the latest information is loaded.