### PR TITLE
Fix error thrown when rails ts_schema:generate in Rails 7.2

### DIFF
--- a/lib/ts_schema.rb
+++ b/lib/ts_schema.rb
@@ -17,7 +17,7 @@ module TsSchema
     end
 
     def generate
-      if ActiveRecord::Base.connection.migration_context.needs_migration?
+      if ActiveRecord::Migration.check_all_pending!
         puts "Aborting: There are pending migrations"
       else
         SchemaGenerator.new(@configuration).generate
@@ -25,7 +25,7 @@ module TsSchema
     end
 
     def output_file
-      if ActiveRecord::Base.connection.migration_context.needs_migration?
+      if ActiveRecord::Migration.check_all_pending!
         puts "Aborting: There are pending migrations"
       else
         SchemaGenerator.new(@configuration).output_file

--- a/lib/ts_schema.rb
+++ b/lib/ts_schema.rb
@@ -17,7 +17,7 @@ module TsSchema
     end
 
     def generate
-      if ActiveRecord::Migration.check_all_pending!
+      if check_migrations!
         puts "Aborting: There are pending migrations"
       else
         SchemaGenerator.new(@configuration).generate
@@ -25,11 +25,19 @@ module TsSchema
     end
 
     def output_file
-      if ActiveRecord::Migration.check_all_pending!
+      if check_migrations!
         puts "Aborting: There are pending migrations"
       else
         SchemaGenerator.new(@configuration).output_file
       end
+    end
+
+    private
+
+    def check_migrations!
+      return ActiveRecord::Base.connection.migration_context.needs_migration? if Rails.version < '7'
+
+      ActiveRecord::Migration.check_all_pending!
     end
   end
 end


### PR DESCRIPTION
# ISSUE
- When I run `rails ts_schema:generate`  I get the error:
```bash
$ rails ts_schema:generate 
warning: parser/current is loading parser/ruby33, which recognizes 3.3.6-compliant syntax, but you are running 3.3.5.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
bin/rails aborted!
NoMethodError: undefined method `migration_context' for an instance of ActiveRecord::ConnectionAdapters::PostgreSQLAdapter (NoMethodError)

      if ActiveRecord::Base.connection.migration_context.needs_migration?
                                      ^^^^^^^^^^^^^^^^^^

Tasks: TOP => ts_schema:generate
(See full trace by running task with --trace)
```

# FIX
- Instead of relaying on `ActiveRecord::Base.connection.migration_context.needs_migration?` we now run the method `ActiveRecord::Migration.check_all_pending!` (_available since rails 7_)

## STEPS TO REPRODUCE
Just following the doc:
1. adds `gem 'ts_schema'` to gemfile
2. bundle install
3. rails generate ts_schema:install
4. rails ts_schema:generate


> ruby --version 
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [arm64-darwin23]

> rails --version
Rails 7.2.2